### PR TITLE
feat: export 스크립트 추가 및 github action 추가

### DIFF
--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -1,0 +1,29 @@
+name: Run Export Script
+
+on:
+  push:
+    branches:
+      - ghpages
+
+jobs:
+  export:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+
+      - name: Install pnpm
+        run: npm install -g pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run export script
+        run: pnpm export

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "export": "pnpm build && cp -r dist docs",
     "lint": "eslint .",
     "preview": "vite preview"
   },


### PR DESCRIPTION
This pull request includes changes to set up a GitHub Actions workflow for running an export script and adds a new script to the `package.json` file. The most important changes include adding a new workflow file and updating the `scripts` section in `package.json`.

Workflow setup:

* [`.github/workflows/export.yml`](diffhunk://#diff-abd067ac9ffcb98dd6b5da7a1bff2138d3a3a9ced0ba8f74886fbbe3d7686540R1-R29): Added a new GitHub Actions workflow named "Run Export Script" that triggers on pushes to the `ghpages` branch. This workflow checks out the repository, sets up Node.js, installs dependencies using pnpm, and runs the export script.

Script updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R9): Added a new script named `export` that builds the project and copies the `dist` directory to the `docs` directory.